### PR TITLE
Correção dos links

### DIFF
--- a/docs/desenho/base/1.1/requisitos/brainstorming.md
+++ b/docs/desenho/base/1.1/requisitos/brainstorming.md
@@ -49,28 +49,28 @@ Seguindo as mesmas perguntas guias, foi realizada uma sessão de brainstorming p
 
 | Número | Requisito |
 |:-:|-|
-| 1 | O [usuário](../lexico/#l7-usuario) deve ser capaz de realizar seu cadastro por email |
-| 2 | O [usuário](../lexico/#l7-usuario) deve ser capaz de realizar seu cadastro pelo facebook |
-| 3 | O [usuário](../lexico/#l7-usuario) deve ser capaz de realizar seu cadastro pelo google |
-| 4 | O [usuário](../lexico/#l7-usuario) deve ser capaz de alterar seu dados (email, nome, telefone, senha, endereço, foto de perfil) |
-| 5 | O [usuário](../lexico/#l7-usuario) deve ser capaz de desativar sua conta |
-| 6 | O [usuário](../lexico/#l7-usuario) deve ser capaz de excluir sua conta |
-| 7 | O [usuário](../lexico/#l7-usuario) deve ser capaz de realizar login utilizando impressão digital |
-| 8 | O [comprador](../lexico/#l7-usuario) deve ser capaz de [avaliar](../lexico/#l5-avaliar) um [vendedor](../lexico/#l7-usuario) |
-| 9 | O [vendedor](../lexico/#l7-usuario) deve ser capaz de [avaliar](../lexico/#l5-avaliar) um [comprador](../lexico/#l7-usuario) |
-| 10 | O [usuário](../lexico/#l7-usuario) deve ser capaz de [reportar](../lexico/#l6-reportar) outro [usuário](../lexico/#l7-usuario) |
-| 11 | O [vendedor](../lexico/#l7-usuario) deve ser capaz de criar um [anúncio](../lexico/#l1-anuncio) |
-| 12 | O [vendedor](../lexico/#l7-usuario) deve ser capaz de adicionar fotos a um [anúncio](../lexico/#l1-anuncio) |
-| 13 | O [vendedor](../lexico/#l7-usuario) deve ser capaz de adicionar palavras chave a um [anúncio](../lexico/#l1-anuncio) |
-| 14 | O [usuário](../lexico/#l7-usuario) deve ser capaz de enviar mensagens para outros [usuários](../lexico/#l7-usuario) |
-| 15 | O [moderador](../lexico/#l7-usuario) deve ser capaz de banir um [usuário](../lexico/#l7-usuario) |
-| 16 | O [moderador](../lexico/#l7-usuario) deve ser capaz de excluir um [anúncio](../lexico/#l1-anuncio) |
-| 17 | O [usuário](../lexico/#l7-usuario) deve ser capaz de visualizar um [anúncio](../lexico/#l1-anuncio) |
-| 18 | O [usuário](../lexico/#l7-usuario) deve ser capaz de filtrar os [anúncios](../lexico/#l1-anuncio)|
-| 19 | O [comprador](../lexico/#l7-usuario) e [vendedor](../lexico/#l7-usuario) deve ser capaz de acessar o perfil de outros [compradores](../lexico/#l7-usuario) e [vendedores](../lexico/#l7-usuario) |
-| 20 | O [comprador](../lexico/#l7-usuario) e [vendedor](../lexico/#l7-usuario) deve ser capaz de bloquear mensagens de outros [compradores](../lexico/#l7-usuario) e [vendedores](../lexico/#l7-usuario) |
-| 21 | O [usuário](../lexico/#l7-usuario) deve ser capaz de interagir com o feed de [anúncios](../lexico/#l1-anuncio) |
-| 22 | O [usuário](../lexico/#l7-usuario) deve ser capaz de escolher os tópicos de [anúncios](../lexico/#l1-anuncio) que deseja visualizar no seu feed [**(a ser decidido)**](../padroes/#a-ser-decidido) |
+| 1 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de realizar seu cadastro por email |
+| 2 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de realizar seu cadastro pelo facebook |
+| 3 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de realizar seu cadastro pelo google |
+| 4 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de alterar seu dados (email, nome, telefone, senha, endereço, foto de perfil) |
+| 5 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de desativar sua conta |
+| 6 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de excluir sua conta |
+| 7 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de realizar login utilizando impressão digital |
+| 8 | O [comprador](../../lexico/#l7-usuario) deve ser capaz de [avaliar](../../lexico/#l5-avaliar) um [vendedor](../../lexico/#l7-usuario) |
+| 9 | O [vendedor](../../lexico/#l7-usuario) deve ser capaz de [avaliar](../../lexico/#l5-avaliar) um [comprador](../../lexico/#l7-usuario) |
+| 10 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de [reportar](../../lexico/#l6-reportar) outro [usuário](../../lexico/#l7-usuario) |
+| 11 | O [vendedor](../../lexico/#l7-usuario) deve ser capaz de criar um [anúncio]../(../lexico/#l1-anuncio) |
+| 12 | O [vendedor](../../lexico/#l7-usuario) deve ser capaz de adicionar fotos a um [anúncio](../../lexico/#l1-anuncio) |
+| 13 | O [vendedor](../../lexico/#l7-usuario) deve ser capaz de adicionar palavras chave a um [anúncio](../../lexico/#l1-anuncio) |
+| 14 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de enviar mensagens para outros [usuários](../../lexico/#l7-usuario) |
+| 15 | O [moderador](../../lexico/#l7-usuario) deve ser capaz de banir um [usuário]../(../lexico/#l7-usuario) |
+| 16 | O [moderador](../../lexico/#l7-usuario) deve ser capaz de excluir um [anúncio]../(../lexico/#l1-anuncio) |
+| 17 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de visualizar um [anúncio]../(../lexico/#l1-anuncio) |
+| 18 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de filtrar os [anúncios]../(../lexico/#l1-anuncio)|
+| 19 | O [comprador](../../lexico/#l7-usuario) e [vendedor](../../lexico/#l7-usuario) deve ser capaz de acessar o perfil de outros [compradores](../../lexico/#l7-usuario) e [vendedores]../(../lexico/#l7-usuario) |
+| 20 | O [comprador](../../lexico/#l7-usuario) e [vendedor](../../lexico/#l7-usuario) deve ser capaz de bloquear mensagens de outros [compradores](../../lexico/#l7-usuario) e [vendedores]../(../lexico/#l7-usuario) |
+| 21 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de interagir com o feed de [anúncios](../../lexico/#l1-anuncio) |
+| 22 | O [usuário](../../lexico/#l7-usuario) deve ser capaz de escolher os tópicos de [anúncios](../../lexico/#l1-anuncio) que deseja visualizar no seu feed [**(a ser decidido)**](../padroes/#a-ser-decidido) |
 | 23 | O sistema deve utilizar reconhecimento de imagem nas fotos dos jogos para aferir a qualidade da mídia |
 | 24 | O sistema deve utilizar reconhecimento de imagem nas fotos de usuário e anúncios para filtrar imagens impróprias |
 
@@ -78,14 +78,14 @@ Seguindo as mesmas perguntas guias, foi realizada uma sessão de brainstorming p
 
 | Número | Requisito |
 |:-:|-|
-| 1 | O sistema deve enviar um e-mail de confirmação para o [usuário](../lexico/#l7-usuario) após o cadastro |
+| 1 | O sistema deve enviar um e-mail de confirmação para o [usuário](../../lexico/#l7-usuario) após o cadastro |
 | 2 | O sistema deve fornecer um modo noturno |
 | 3 | O sistema deve possuir uma página de criação de anúncios intuitiva [**(a ser decidido)**](../padroes/#a-ser-decidido) |
 | 4 | O sistema deve ser gamificado [**(a ser decidido)**](../padroes/#a-ser-decidido) |
 | 5 | O sistema deve ser amigável [**(a ser decidido)**](../padroes/#a-ser-decidido) |
 | 6 | O sistema deve possuir uma boa usabilidade [**(a ser decidido)**](../padroes/#a-ser-decidido) |
-| 7 | O sistema deve exibir somente perfis de [compradores](../lexico/#l7-usuario) e [vendedores](../lexico/#l7-usuario) |
-| 8 | O sistema deve filtrar palavras impróprias em [anúncios](../lexico/#l1-anuncio) [**(a ser decidido)**](../padroes/#a-ser-decidido) |
+| 7 | O sistema deve exibir somente perfis de [compradores](../../lexico/#l7-usuario) e [vendedores](../../lexico/#l7-usuario) |
+| 8 | O sistema deve filtrar palavras impróprias em [anúncios](../../lexico/#l1-anuncio) [**(a ser decidido)**](../padroes/#a-ser-decidido) |
 
 ## Referências
 

--- a/docs/desenho/base/1.1/requisitos/introspeccao.md
+++ b/docs/desenho/base/1.1/requisitos/introspeccao.md
@@ -3,7 +3,7 @@
 ## Introdução
 
 <p style="text-indent: 20px; text-align: justify">
-O método de introspecção consiste em se colocar no papel dos usuários do sistema e imaginar o que os mesmos gostariam e/ou necessitariam que o sistema cumprisse para suprir as suas necessidades, e também suas características. Neste processo, utilizaremos <a href="/desenho/base/1.1/personas">personas</a> para tornar o processo de identificação e interpretação dos usuários-alvo do sistema mais fácil.
+O método de introspecção consiste em se colocar no papel dos usuários do sistema e imaginar o que os mesmos gostariam e/ou necessitariam que o sistema cumprisse para suprir as suas necessidades, e também suas características. Neste processo, utilizaremos <a href="../../personas">personas</a> para tornar o processo de identificação e interpretação dos usuários-alvo do sistema mais fácil.
 </p>
 
 ## Requisitos
@@ -40,21 +40,21 @@ O método de introspecção consiste em se colocar no papel dos usuários do sis
 
 <tr>
 <td style="text-align: center">4</td>
-<td style="text-align: justify">O comprador deve ser capaz de <a href="/lexico/#l6-reportar">reportar</a> um anúncio feito por um vendedor</td>
+<td style="text-align: justify">O comprador deve ser capaz de <a href="../../lexico/#l6-reportar">reportar</a> um anúncio feito por um vendedor</td>
 <td><a href="../../personas/#persona-1-thomas-araujo-souza">Thomas</a></td>
 <td>Funcional</td>
 </tr>
 
 <tr>
 <td style="text-align: center">5</td>
-<td style="text-align: justify">O comprador deve ser capaz de <a href="/lexico/#l5-avaliar">avaliar</a> um vendedor após realizar uma troca ou compra</td>
+<td style="text-align: justify">O comprador deve ser capaz de <a href="../../lexico/#l5-avaliar">avaliar</a> um vendedor após realizar uma troca ou compra</td>
 <td><a href="../../personas/#persona-1-thomas-araujo-souza">Thomas</a></td>
 <td>Funcional</td>
 </tr>
 
 <tr>
 <td style="text-align: center">6</td>
-<td style="text-align: justify">O vendedor deve ser capaz de <a href="/lexico/#l5-avaliar">avaliar</a> um comprador após a realização de uma compra ou troca</td>
+<td style="text-align: justify">O vendedor deve ser capaz de <a href="../../lexico/#l5-avaliar">avaliar</a> um comprador após a realização de uma compra ou troca</td>
 <td><a href="../../personas/#persona-2-carlos-macedo-dos-santos">Carlos</a></td>
 <td>Funcional</td>
 </tr>
@@ -117,14 +117,14 @@ O método de introspecção consiste em se colocar no papel dos usuários do sis
 
 <tr>
 <td style="text-align: center">15</td>
-<td style="text-align: justify">O moderador deve ser capaz de <a href="/lexico/#l8-invalidar">invalidar</a> um anúncio</td>
+<td style="text-align: justify">O moderador deve ser capaz de <a href="../../lexico/#l8-invalidar">invalidar</a> um anúncio</td>
 <td><a href="../../personas/#persona-3-sarah-brenda-campos">Sarah</a></td>
 <td>Funcional</td>
 </tr>
 
 <tr>
 <td style="text-align: center">16</td>
-<td style="text-align: justify">O sistema deverá notificar o vendedor caso seu anúncio seja <a href="/lexico/#l8-invalidar">invalidado</a></td>
+<td style="text-align: justify">O sistema deverá notificar o vendedor caso seu anúncio seja <a href="/../..lexico/#l8-invalidar">invalidado</a></td>
 <td><a href="../../personas/#persona-3-sarah-brenda-campos">Sarah</a> e <a href="../../personas/#persona-2-carlos-macedo-dos-santos">Carlos</a></td>
 <td>Funcional</td>
 </tr>
@@ -132,21 +132,21 @@ O método de introspecção consiste em se colocar no papel dos usuários do sis
 
 <tr>
 <td style="text-align: center">17</td>
-<td style="text-align: justify">O sistema deve listar apenas <a href="/lexico/#l9-anuncio-valido">anúncios válidos</a></td>
+<td style="text-align: justify">O sistema deve listar apenas <a href="../../lexico/#l9-anuncio-valido">anúncios válidos</a></td>
 <td><a href="../../personas/#persona-1-thomas-araujo-souza">Thomas</a></td>
 <td>Funcional</td>
 </tr>
 
 <tr>
 <td style="text-align: center">18</td>
-<td style="text-align: justify">O sistema deverá notificar o usuário quando um <a href="/lexico/#l1-anuncio">anúncio</a> que ele reportou for <a href="/lexico/#l8-invalidar">invalidado</a></td>
+<td style="text-align: justify">O sistema deverá notificar o usuário quando um <a href="/../..lexico/#l1-anuncio">anúncio</a> que ele reportou for <a href="../../lexico/#l8-invalidar">invalidado</a></td>
 <td><a href="../../personas/#persona-3-sarah-brenda-campos">Sarah</a> e <a href="../../personas/#persona-1-thomas-araujo-souza">Thomas</a></td>
 <td>Funcional</td>
 </tr>
 
 <tr>
 <td style="text-align: center">19</td>
-<td style="text-align: justify">O vendedor deve ser capaz de remover um <a href="/lexico/#l1-anuncio">anúncio</a></td>
+<td style="text-align: justify">O vendedor deve ser capaz de remover um <a href="../../lexico/#l1-anuncio">anúncio</a></td>
 <td><a href="../../personas/#persona-2-carlos-macedo-dos-santos">Carlos</a></td>
 <td>Funcional</td>
 </tr>
@@ -174,14 +174,14 @@ O método de introspecção consiste em se colocar no papel dos usuários do sis
 
 <tr>
 <td style="text-align: center">23</td>
-<td style="text-align: justify">O moderador deve ser capaz de banir um <a href="/lexico/#l7-usuario">usuário</a> (<a href="/requisitos/padroes/#a-ser-decidido"><strong>a ser decidido</strong></a>)</td>
+<td style="text-align: justify">O moderador deve ser capaz de banir um <a href="../../lexico/#l7-usuario">usuário</a> (<a href="../padroes/#a-ser-decidido"><strong>a ser decidido</strong></a>)</td>
 <td><a href="../../personas/#persona-3-sarah-brenda-campos">Sarah</a></td>
 <td>Funcional</td>
 </tr>
 
 <tr>
 <td style="text-align: center">24</td>
-<td style="text-align: justify">O sistema no momento de cadastro, deve pedir o consentimento dos usuários em relação aos termos de uso (<a href="/requisitos/padroes/#a-ser-decidido"><strong>a ser decidido</strong></a>)</td>
+<td style="text-align: justify">O sistema no momento de cadastro, deve pedir o consentimento dos usuários em relação aos termos de uso (<a href="../padroes/#a-ser-decidido"><strong>a ser decidido</strong></a>)</td>
 <td><a href="../../personas/#persona-1-thomas-araujo-souza">Thomas</a>, <a href="../../personas/#persona-2-carlos-macedo-dos-santos">Carlos</a> e <a href="../../personas/#persona-3-sarah-brenda-campos">Sarah</a></td>
 <td>Funcional</td>
 </tr>
@@ -223,14 +223,14 @@ O método de introspecção consiste em se colocar no papel dos usuários do sis
 
 <tr>
 <td style="text-align: center">30</td>
-<td style="text-align: justify">O sistema deve possibilitar uma navegabilidade ágil entre as funcionalidades (<a href="/requisitos/padroes/#a-ser-decidido"><strong>a ser decidido</strong></a>)</td>
+<td style="text-align: justify">O sistema deve possibilitar uma navegabilidade ágil entre as funcionalidades (<a href="../padroes/#a-ser-decidido"><strong>a ser decidido</strong></a>)</td>
 <td><a href="../../personas/#persona-1-thomas-araujo-souza">Thomas</a>, <a href="../../personas/#persona-2-carlos-macedo-dos-santos">Carlos</a> e <a href="../../personas/#persona-3-sarah-brenda-campos">Sarah</a></td>
 <td>Não funcional</td>
 </tr>
 
 <tr>
 <td style="text-align: center">31</td>
-<td style="text-align: justify">A interface do sistema deverá possuir uma boa usabilidade (<a href="/requisitos/padroes/#a-ser-decidido"><strong>a ser decidido</strong></a>)</td>
+<td style="text-align: justify">A interface do sistema deverá possuir uma boa usabilidade (<a href="../padroes/#a-ser-decidido"><strong>a ser decidido</strong></a>)</td>
 <td><a href="../../personas/#persona-2-carlos-macedo-dos-santos">Carlos</a>, <a href="../../personas/#persona-1-thomas-araujo-souza">Thomas</a> e <a href="../../personas/#persona-3-sarah-brenda-campos">Sarah</a></td>
 <td>Não funcional</td>
 </tr>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - 2.1.3 Modelagem ágil:
         - Backlog de produto: desenho/modelagem/2.3/backlog_produto.md
       - Iniciativas extras:
-        - Atributos de Qualidades: desenho/modelagem/iniciativa/atributos_qualidade.md
+        - Atributos de Qualidade: desenho/modelagem/iniciativa/atributos_qualidade.md
         - Especificação Suplementar (SRS): desenho/modelagem/iniciativa/especificacao_suplementar.md
   - Versões documentos:
     - Rich Picture:


### PR DESCRIPTION
# Correção dos links no documento de brainstorming

## Descrição 
Correção nos links da wiki

[Consertar todos os links quebrados](https://github.com/UnBArqDsw2020-2/2020.2_G7_gXchange_DOCS/issues/98)

## Porque este Pull Request é necessário?
integra a correção nos links da wiki

## Critérios de aceitação

1. [ ] Diagrama de estados - Link para o documento de léxico
2. [ ] Arquivo de Introspecção - Todos os links para o documento de léxico estão quebrados
3. [ ] Arquivo de Introspecção - Link para o documento de personas na introdução
4. [ ] Arquivo de Brainstorming - Todos os links para o documento de léxico estão quebrados
5. [ ] Arquivo de Especificação suplementar - Link para o documento de padrões

Resolve #98  
